### PR TITLE
Change project name to "arduino/setup-task"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,8 @@ contact_links:
   - name: Learn about GitHub Actions
     url: https://docs.github.com/en/actions
     about: Everything you need to know to get started with GitHub Actions.
-  - name: Learn about using the arduino/setup-taskfile action
-    url: https://github.com/arduino/setup-taskfile#readme
+  - name: Learn about using the arduino/setup-task action
+    url: https://github.com/arduino/setup-task#readme
     about: Detailed usage documentation is available here.
   - name: Support request
     url: https://forum.arduino.cc/

--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/actions/setup-taskfile@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Initialize markdownlint-cli problem matcher
         uses: xt0rted/markdownlint-problem-matcher@v1
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/actions/setup-taskfile@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/actions/setup-taskfile@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-typescript-task.yml
+++ b/.github/workflows/check-typescript-task.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/actions/setup-taskfile@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -82,14 +82,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run action, using invalid version
-        id: setup-taskfile
+        id: setup-task
         continue-on-error: true
         uses: ./
         with:
           version: 2.42.x
 
       - name: Fail the job if the action run succeeded
-        if: steps.setup-taskfile.outcome == 'success'
+        if: steps.setup-task.outcome == 'success'
         run: |
           echo "::error::The action run was expected to fail, but passed!"
           exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,6 @@ See [step-debug-logs](https://github.com/actions/toolkit/blob/master/docs/action
 
 Instructions for releasing a new version of the action:
 
-1. If the release will increment the major version, update the action refs in the examples in README.md (e.g., `uses: arduino/setup-taskfile@v1` -> `uses: arduino/setup-taskfile@v2`).
+1. If the release will increment the major version, update the action refs in the examples in README.md (e.g., `uses: arduino/setup-task@v1` -> `uses: arduino/setup-task@v2`).
 1. Create a [GitHub release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release), following the `vX.Y.Z` tag name convention. Make sure to follow [the SemVer specification](https://semver.org/).
 1. Rebase the release branch for that major version (e.g., `v1` branch for the `v1.x.x` tags) on the tag. If no branch exists for the release's major version, create one.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# `arduino/setup-taskfile`
+# `arduino/setup-task`
 
-[![Check TypeScript status](https://github.com/arduino/setup-taskfile/actions/workflows/check-typescript-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-typescript-task.yml)
-[![Check TypeScript Configuration status](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml)
-[![Check npm status](https://github.com/arduino/setup-taskfile/actions/workflows/check-npm.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-npm.yml)
-[![Integration Tests status](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml)
-[![Check Action Metadata status](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml)
-[![Check Markdown status](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml)
-[![Spell Check status](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check-task.yml)
-[![Check License status](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml)
+[![Check TypeScript status](https://github.com/arduino/setup-task/actions/workflows/check-typescript-task.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-typescript-task.yml)
+[![Check TypeScript Configuration status](https://github.com/arduino/setup-task/actions/workflows/check-tsconfig.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-tsconfig.yml)
+[![Check npm status](https://github.com/arduino/setup-task/actions/workflows/check-npm.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-npm.yml)
+[![Integration Tests status](https://github.com/arduino/setup-task/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/test-integration.yml)
+[![Check Action Metadata status](https://github.com/arduino/setup-task/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-action-metadata-task.yml)
+[![Check Markdown status](https://github.com/arduino/setup-task/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-markdown-task.yml)
+[![Spell Check status](https://github.com/arduino/setup-task/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/spell-check-task.yml)
+[![Check License status](https://github.com/arduino/setup-task/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-task/actions/workflows/check-license.yml)
 
 A [GitHub Actions](https://docs.github.com/en/actions) action that makes the [Task](https://taskfile.dev/#/) task runner / build tool available to use in your workflow.
 
@@ -32,15 +32,15 @@ It will be convenient to use [`${{ secrets.GITHUB_TOKEN }}`](https://docs.github
 To get the action's default version of Task just add this step:
 
 ```yaml
-- name: Install Taskfile
-  uses: arduino/setup-taskfile@main
+- name: Install Task
+  uses: arduino/setup-task@main
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
-- name: Install Taskfile
-  uses: arduino/setup-taskfile@main
+- name: Install Task
+  uses: arduino/setup-task@main
   with:
     version: '2.x'
 ```
@@ -48,8 +48,8 @@ If you want to pin a major or minor version you can use the `.x` wildcard:
 To pin the exact version:
 
 ```yaml
-- name: Install Taskfile
-  uses: arduino/setup-taskfile@main
+- name: Install Task
+  uses: arduino/setup-task@main
   with:
     version: '2.6.1'
 ```
@@ -57,7 +57,7 @@ To pin the exact version:
 ## Security
 
 If you think you found a vulnerability or other security-related bug in this project, please read our
-[security policy](https://github.com/arduino/setup-taskfile/security/policy) and report the bug to our Security Team 🛡️
+[security policy](https://github.com/arduino/setup-task/security/policy) and report the bug to our Security Team 🛡️
 Thank you!
 
 e-mail contact: security@arduino.cc

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 ARDUINO SA
 //
 // The software is released under the GNU General Public License, which covers the main body
-// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// of the arduino/setup-task code. The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 // You can be released from the requirements of the above licenses by purchasing

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Task'
+name: 'arduino/setup-task'
 description: 'Download Task and add it to the PATH'
 author: 'Arduino'
 inputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,7 @@
 // Copyright (c) 2019 ARDUINO SA
 //
 // The software is released under the GNU General Public License, which covers the main body
-// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// of the arduino/setup-task code. The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 // You can be released from the requirements of the above licenses by purchasing
@@ -78,12 +78,12 @@ function fetchVersions(repoToken) {
     return __awaiter(this, void 0, void 0, function* () {
         let rest;
         if (repoToken !== "") {
-            rest = new restm.RestClient("setup-taskfile", "", [], {
+            rest = new restm.RestClient("setup-task", "", [], {
                 headers: { Authorization: `Bearer ${repoToken}` }
             });
         }
         else {
-            rest = new restm.RestClient("setup-taskfile");
+            rest = new restm.RestClient("setup-task");
         }
         const tags = (yield rest.get("https://api.github.com/repos/go-task/task/git/refs/tags")).result || [];
         return tags
@@ -224,7 +224,7 @@ exports.getTask = getTask;
 // Copyright (c) 2019 ARDUINO SA
 //
 // The software is released under the GNU General Public License, which covers the main body
-// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// of the arduino/setup-task code. The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 // You can be released from the requirements of the above licenses by purchasing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "setup-taskfile",
+  "name": "setup-task",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "setup-taskfile",
+  "name": "setup-task",
   "version": "0.0.0",
   "private": true,
   "description": "Setup Task action",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/arduino/setup-taskfile.git"
+    "url": "git+https://github.com/arduino/setup-task.git"
   },
   "keywords": [
     "actions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "setup-taskfile"
+name = "setup-task"
 version = "0.0.0"
 description = "GitHub Actions action to install Task"
 authors = ["Arduino <info@arduino.cc>"]

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 ARDUINO SA
 //
 // The software is released under the GNU General Public License, which covers the main body
-// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// of the arduino/setup-task code. The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 // You can be released from the requirements of the above licenses by purchasing
@@ -47,11 +47,11 @@ interface ITaskRef {
 async function fetchVersions(repoToken: string): Promise<string[]> {
   let rest: restm.RestClient;
   if (repoToken !== "") {
-    rest = new restm.RestClient("setup-taskfile", "", [], {
+    rest = new restm.RestClient("setup-task", "", [], {
       headers: { Authorization: `Bearer ${repoToken}` }
     });
   } else {
-    rest = new restm.RestClient("setup-taskfile");
+    rest = new restm.RestClient("setup-task");
   }
 
   const tags: ITaskRef[] =

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2019 ARDUINO SA
 //
 // The software is released under the GNU General Public License, which covers the main body
-// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// of the arduino/setup-task code. The terms of this license can be found at:
 // https://www.gnu.org/licenses/gpl-3.0.en.html
 //
 // You can be released from the requirements of the above licenses by purchasing


### PR DESCRIPTION
[The Task documentation](https://taskfile.dev/#/) consistently refers to the tool as "Task". Taskfile is the term used for Task's configuration file.
This action is setting up the Task tool, not setting up the Task configuration file, so "arduino/setup-task" is more
appropriate than "arduino/setup-taskfile".