### PR TITLE
Add CI workflow to check Markdown files for problems

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,0 +1,67 @@
+name: Check Markdown
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-markdown-task.yml"
+      - ".markdown-link-check.json"
+      - "Taskfile.yml"
+      - "**/.markdownlint*"
+      - "**.md"
+      - "**.mdx"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  pull_request:
+    paths:
+      - ".github/workflows/check-markdown-task.yml"
+      - ".markdown-link-check.json"
+      - "Taskfile.yml"
+      - "**/.markdownlint*"
+      - "**.md"
+      - "**.mdx"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize markdownlint-cli problem matcher
+        uses: xt0rted/markdownlint-problem-matcher@v1
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Lint
+        run: task markdown:lint
+
+  links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check links
+        run: task --silent markdown:check-links

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,5 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206]
+}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,59 @@
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
+
+default: false
+MD001: false
+MD002: false
+MD003: false # Prettier
+MD004: false # Prettier
+MD005: false # Prettier
+MD006: false # Prettier
+MD007: false # Prettier
+MD008: false # Prettier
+MD009:
+  br_spaces: 0
+  strict: true
+  list_item_empty_lines: false # Prettier
+MD010: false # Prettier
+MD011: true
+MD012: false # Prettier
+MD013: false
+MD014: false
+MD018: true
+MD019: false # Prettier
+MD020: true
+MD021: false # Prettier
+MD022: false # Prettier
+MD023: false # Prettier
+MD024: false
+MD025:
+  level: 1
+  front_matter_title: '^\s*"?title"?\s*[:=]'
+MD026: false
+MD027: false # Prettier
+MD028: false
+MD029:
+  style: one
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1
+MD031: false # Prettier
+MD032: false # Prettier
+MD033: false
+MD034: false
+MD035: false # Prettier
+MD036: false
+MD037: true
+MD038: true
+MD039: true
+MD040: false
+MD041: false
+MD042: true
+MD043: false
+MD044: false
+MD045: true
+MD046:
+  style: fenced
+MD047: false # Prettier

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Check TypeScript Configuration status](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml)
 [![Integration Tests status](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml)
 [![Check Action Metadata status](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml)
+[![Check Markdown status](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml)
 [![Spell Check status](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check.yml)
 [![Check License status](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml)
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![Check TypeScript status](https://github.com/arduino/setup-taskfile/actions/workflows/check-typescript-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-typescript-task.yml)
 [![Check TypeScript Configuration status](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-tsconfig.yml)
+[![Check npm status](https://github.com/arduino/setup-taskfile/actions/workflows/check-npm.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-npm.yml)
 [![Integration Tests status](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml)
 [![Check Action Metadata status](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml)
 [![Check Markdown status](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-markdown-task.yml)
-[![Spell Check status](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check.yml)
+[![Spell Check status](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/spell-check-task.yml)
 [![Check License status](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml)
 
 A [GitHub Actions](https://docs.github.com/en/actions) action that makes the [Task](https://taskfile.dev/#/) task runner / build tool available to use in your workflow.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ tasks:
     deps:
       - task: ts:test
       - task: action:validate
+      - task: markdown:lint
       - task: general:check-spelling
 
   ts:install-deps:
@@ -55,6 +56,27 @@ tasks:
     cmds:
       - wget --quiet --output-document="{{.ACTION_METADATA_SCHEMA_PATH}}" https://json.schemastore.org/github-action
       - npx ajv-cli validate --strict=false -s "{{.ACTION_METADATA_SCHEMA_PATH}}" -d "action.yml"
+
+  markdown:lint:
+    desc: Check for problems in Markdown files
+    cmds:
+      - npx markdownlint-cli "**/*.md"
+
+  markdown:check-links:
+    desc: Check for broken links
+    cmds:
+      - |
+        # NOTE: npx --call uses the native shell, so this task can't be used on Windows.
+        npx --package=markdown-link-check --call='
+        STATUS=0
+        for file in $(find -name "*.md"); do
+          markdown-link-check \
+            --quiet \
+            --config "./.markdown-link-check.json" \
+            "$file"
+          STATUS=$(( $STATUS + $? ))
+        done
+        exit $STATUS'
 
   general:check-spelling:
     desc: Check for commonly misspelled words


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
problems:

- Use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check for common problems and formatting.
- Use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links.

Arduino's Markdown style is defined by the `.markdownlint.yml` file.

In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them via a `.markdownlintignore` file:
https://github.com/igorshubovych/markdownlint-cli#ignoring-files

markdown-link-check is configured via the `.markdown-link-check.json` file:
https://github.com/tcort/markdown-link-check#config-file-format