### PR TITLE
Remove redundant default version code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "Arduino"
 inputs:
   version:
     description: "Version to use. Example: 3.4.2"
-    required: false
+    required: true
     default: "3.x"
   repo-token:
     description: "Token with permissions to do repo things"

--- a/dist/index.js
+++ b/dist/index.js
@@ -266,14 +266,9 @@ const installer = __importStar(__nccwpck_require__(1480));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let version = core.getInput("version");
+            const version = core.getInput("version", { required: true });
             const repoToken = core.getInput("repo-token");
-            if (!version) {
-                version = "2.x";
-            }
-            if (version) {
-                yield installer.getTask(version, repoToken);
-            }
+            yield installer.getTask(version, repoToken);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,15 +15,10 @@ import * as installer from "./installer";
 
 async function run() {
   try {
-    let version = core.getInput("version");
+    const version = core.getInput("version", { required: true });
     const repoToken = core.getInput("repo-token");
-    if (!version) {
-      version = "2.x";
-    }
 
-    if (version) {
-      await installer.getTask(version, repoToken);
-    }
+    await installer.getTask(version, repoToken);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
The default value of the `version` input is defined in the action metadata, so having another default setting in the code
is purely redundant and doubles the maintenance effort required on every major release of Task (note that they already
went out of sync).