### PR TITLE
Configure Dependabot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Even though the project's current use of Python is insignificant, we already have the infrastructure in place and
Dependabot has been very useful for the other dependencies, so it makes sense to use it for everything.

Reference:
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file

---
### Related
- https://github.com/per1234/setup-task/pull/1
- https://github.com/per1234/setup-task/pull/15