### PR TITLE
Validate tsconfig.eslint.json

### DIFF
--- a/.github/workflows/check-tsconfig.yml
+++ b/.github/workflows/check-tsconfig.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         file:
           - ./tsconfig.json
+          - ./tsconfig.eslint.json
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
At the time the "Check TypeScript Configuration" workflow was created, the eslint proposal was still pending, so only
tsconfig.json was validated in the initial implementation of the workflow.

Now that the project contains two tsconfig files and the infrastructure is in place to easily validate any number of
these files, it might as well be used to the fullest extent.