### PR TITLE
Remove version field from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "setup-task",
-  "version": "0.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@actions/core": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "setup-task",
-  "version": "0.0.0",
   "private": true,
   "description": "Setup Task action",
   "main": "lib/main.js",


### PR DESCRIPTION
The `version` field is only needed if the package is to be published. For this project, packge.json is only used to
define dependencies. For this reason, having a `version` field is harmful because it increases the effort and complexity
of making a release, and also is likely to get out of sync with the true version.

Reference:
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#version
>If you don't plan to publish your package, the name and version fields are optional.