### PR TITLE
Remove unused `tempDirectory` definition code

### DIFF
--- a/.github/workflows/test-typescript-task.yml
+++ b/.github/workflows/test-typescript-task.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Node.js 10.x
+      - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 12.x

--- a/dist/index.js
+++ b/dist/index.js
@@ -47,7 +47,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getTask = void 0;
-// Load tempDirectory before it gets wiped by tool-cache
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
 const util = __importStar(__nccwpck_require__(1669));
@@ -55,21 +54,6 @@ const restm = __importStar(__nccwpck_require__(7405));
 const semver = __importStar(__nccwpck_require__(1383));
 const core = __importStar(__nccwpck_require__(2186));
 const tc = __importStar(__nccwpck_require__(7784));
-let tempDirectory = process.env.RUNNER_TEMP || "";
-if (!tempDirectory) {
-    let baseLocation;
-    if (process.platform === "win32") {
-        // On windows use the USERPROFILE env variable
-        baseLocation = process.env.USERPROFILE || "C:\\";
-    }
-    else if (process.platform === "darwin") {
-        baseLocation = "/Users";
-    }
-    else {
-        baseLocation = "/home";
-    }
-    tempDirectory = path.join(baseLocation, "actions", "temp");
-}
 const io = __nccwpck_require__(7436);
 const osPlat = os.platform();
 const osArch = os.arch();

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,7 +10,6 @@
 // software without disclosing the source code of your own applications. To purchase
 // a commercial license, send an email to license@arduino.cc
 
-// Load tempDirectory before it gets wiped by tool-cache
 import * as os from "os";
 import * as path from "path";
 import * as util from "util";
@@ -20,20 +19,6 @@ import * as semver from "semver";
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
 
-let tempDirectory = process.env.RUNNER_TEMP || "";
-
-if (!tempDirectory) {
-  let baseLocation;
-  if (process.platform === "win32") {
-    // On windows use the USERPROFILE env variable
-    baseLocation = process.env.USERPROFILE || "C:\\";
-  } else if (process.platform === "darwin") {
-    baseLocation = "/Users";
-  } else {
-    baseLocation = "/home";
-  }
-  tempDirectory = path.join(baseLocation, "actions", "temp");
-}
 import io = require("@actions/io");
 
 const osPlat: string = os.platform();


### PR DESCRIPTION
`tempDirectory` is not used anywhere in the code and was causing the linting of imports to fail.